### PR TITLE
ci(): adding quality-check and semantic-release workflows

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -1,0 +1,47 @@
+name: Version Release and NPM Publish
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  NODE_VERSION: 20.11.0
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  version-release:
+    name: Version Release Package
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - uses: mskelton/setup-yarn@v1
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          run_install: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install Dependencies
+        run: yarn
+
+      - name: Build Package
+        run: yarn build
+
+      - name: Unit Tests
+        run: yarn test
+
+      - name: Semantic Release
+        run: npx semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # todo: NPM publish step

--- a/.github/workflows/quality-check.yaml
+++ b/.github/workflows/quality-check.yaml
@@ -1,0 +1,46 @@
+name: Code Quality
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+env:
+  NODE_VERSION: 20.11.0
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  code-quality:
+    name: Code Quality Checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - uses: mskelton/setup-yarn@v1
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          run_install: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install Dependencies
+        run: yarn
+
+      - name: Prettier
+        run: yarn format
+
+      - name: ESLint
+        run: yarn lint
+
+      - name: Test Coverage
+        run: yarn test

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "format": "prettier --write 'src/**/*.{js,ts,json,css,md}'",
     "test": "jest",
     "test:watch": "jest --watch",
-    "prepublish": "yarn lint && yarn format && yarn test && yarn build",
     "prepare": "husky"
   },
   "dependencies": {


### PR DESCRIPTION
### Workflows

- adding a quality check workflow
- adding a semantic release for version control workflow

note: the semantic release is in the npm-publish workflow, but the npm publish is not implemented yet

jira: [https://brillion-jira.atlassian.net/browse/BRIL-497]