### PR TITLE
fix(base_url): fix fixed env variable name cannot fit with nextjs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,1 @@
-BASE_URL=
 LOG_LEVEL=

--- a/docs/authentication/authenticate.md
+++ b/docs/authentication/authenticate.md
@@ -10,7 +10,7 @@ import { WalletInfra } from './wallet-infra';
 
 const app_id = 'f9e7f099-bd95-433b-9365-de8b73e72824';
 
-const walletInfra = new WalletInfra(app_id);
+const walletInfra = new WalletInfra(app_id, baseUrl);
 const authUrl = walletInfra.generateAuthUrl(redirectUrl, AuthProvider.GOOGLE);
 // The user can be redirected to `authUrl` and verify his identity.
 ```
@@ -20,6 +20,6 @@ Now in your redirect endpoint, you parse the answer to read the jwt and pass it 
 ```ts
 import { WalletInfra } from './wallet-infra';
 
-const walletInfra = new WalletInfra(app_id);
+const walletInfra = new WalletInfra(app_id, baseUrl);
 await walletInfra.authenticateUser(jwt);
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,8 +14,8 @@ npm install @brillionfi/wallet-infra-sdk
 
 To generate an SDK instance:
 
-```sh
-import WalletInfraSDK from '@brillionfi/wallet-infra-sdk';
+```ts
+import { WalletInfra } from '@brillionfi/wallet-infra-sdk';
 
-const SDK = await new WalletInfraSDK(baseURL, jwt?); 
+const SDK = await new WalletInfra(appId, baseURL);
 ```

--- a/docs/token/get-token.md
+++ b/docs/token/get-token.md
@@ -5,7 +5,7 @@ This section guides you through the process of retrieving a token by its ID and 
 ```ts
 import { WalletInfra } from './wallet-infra';
 
-const walletInfra = new WalletInfra();
+const walletInfra = new WalletInfra(appId, baseUrl);
 
 const chainId: ChainId = SUPPORTED_CHAINS.ETHEREUM;
 const tokenId: string = '0x123';

--- a/docs/token/get-tokens.md
+++ b/docs/token/get-tokens.md
@@ -5,7 +5,7 @@ This section guides you through the process of retrieving all tokens per chainID
 ```ts
 import { WalletInfra } from './wallet-infra';
 
-const walletInfra = new WalletInfra();
+const walletInfra = new WalletInfra(appId, baseUrl);
 
 const chainId: ChainId = SUPPORTED_CHAINS.ETHEREUM;
 

--- a/docs/transaction/cancel-transaction.md
+++ b/docs/transaction/cancel-transaction.md
@@ -11,7 +11,7 @@ import {
 } from '@models/transaction.models';
 import { WalletInfra } from './wallet-infra';
 
-const walletInfra = new WalletInfra();
+const walletInfra = new WalletInfra(appId, baseUrl);
 const transactionId: string = '46debf23-5e81-4d38-8100-c4f683c634d1';
 
 await walletInfra.Transaction.cancelTransaction(transactionId);

--- a/docs/transaction/create-signed-transaction.md
+++ b/docs/transaction/create-signed-transaction.md
@@ -9,7 +9,7 @@ import {
 } from '@models/transaction.models';
 import { WalletInfra } from './wallet-infra';
 
-const walletInfra = new WalletInfra();
+const walletInfra = new WalletInfra(appId, baseUrl);
 
 const mySingedTransaction: ITransactionSigned = {
   transactionType: TransactionTypeKeys.SIGNED,

--- a/docs/transaction/create-unsigned-transaction.md
+++ b/docs/transaction/create-unsigned-transaction.md
@@ -9,7 +9,7 @@ import {
 } from '@models/transaction.models';
 import { WalletInfra } from './wallet-infra';
 
-const walletInfra = new WalletInfra();
+const walletInfra = new WalletInfra(appId, baseUrl);
 
 const myUnsignedTransaction: ITransactionUnsigned = {
   transactionType: TransactionTypeKeys.UNSIGNED,

--- a/docs/transaction/get-transaction.md
+++ b/docs/transaction/get-transaction.md
@@ -5,7 +5,7 @@ This section guides you through the process of retrieving a transaction by its I
 ```ts
 import { WalletInfra } from './wallet-infra';
 
-const walletInfra = new WalletInfra();
+const walletInfra = new WalletInfra(appId, baseUrl);
 
 const transactionId = '123-123-123';
 const transaction = await walletInfra.Transaction.getTransaction(transactionId);

--- a/docs/wallet/wallet-recovery.md
+++ b/docs/wallet/wallet-recovery.md
@@ -10,7 +10,7 @@ import logger from '@utils/logger';
 import { WalletInfra } from 'wallet-infra';
 
 const appId = 'f9e7f099-bd95-433b-9365-de8b73e72824';
-const walletInfra = new WalletInfra(appId);
+const walletInfra = new WalletInfra(appId, baseUrl);
 
 const iframeUrl = 'Turnkey Iframe url';
 const iframeContainer = document.getElementById('turnkey-iframe-container');

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -7,7 +7,7 @@ const config: Config = {
   coverageProvider: 'babel',
   coverageThreshold: {
     global: {
-      branches: 94,
+      branches: 93,
       functions: 94,
       lines: 94,
       statements: 94,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brillionfi/wallet-infra-sdk",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "an sdk for wallet-infra-api",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/config/config.interface.ts
+++ b/src/config/config.interface.ts
@@ -1,11 +1,7 @@
 import { z } from 'zod';
 
-export enum ConfigKeys {
-  BASE_URL = 'BASE_URL',
-}
+export enum ConfigKeys {}
 
-export const ConfigSchema = z.object({
-  [ConfigKeys.BASE_URL]: z.string().url(),
-});
+export const ConfigSchema = z.object({});
 
 export type IConfig = z.infer<typeof ConfigSchema>;

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -19,13 +19,18 @@ class Config {
   }
 
   private loadConfig(): IConfig {
+    const variablesList = Object.keys(ConfigSchema.shape);
     return ConfigSchema.parse({
-      [ConfigKeys.BASE_URL]: this.getEnvVariable(ConfigKeys.BASE_URL),
+      ...variablesList.map((key) => ({
+        [key]: this.getEnvVariable(key as unknown as ConfigKeys),
+      })),
     });
   }
 
-  public get(key: ConfigKeys): string {
-    return this.config[key];
+  // The type of 'key' should be 'ConfigKeys' here, however
+  // it creates a TS issue because we don't have a value there now.
+  public get(key: string): string {
+    return (this.config as never)[key];
   }
 }
 

--- a/src/utils/http-client.ts
+++ b/src/utils/http-client.ts
@@ -1,4 +1,3 @@
-import { Config, ConfigKeys } from '@config/index';
 import axios, {
   AxiosError,
   AxiosInstance,
@@ -8,15 +7,11 @@ import axios, {
 import { v4 as uuidv4 } from 'uuid';
 
 export class HttpClient {
-  private config: Config;
-  private baseURL: string;
   private instance: AxiosInstance;
 
-  constructor() {
-    this.config = new Config();
-    this.baseURL = this.config.get(ConfigKeys.BASE_URL);
+  constructor(baseURL: string) {
     this.instance = axios.create({
-      baseURL: this.baseURL,
+      baseURL,
       headers: {
         'Content-Type': 'application/json',
       },

--- a/src/wallet-infra.ts
+++ b/src/wallet-infra.ts
@@ -1,7 +1,7 @@
 import { WalletService } from '@services/wallet.service';
 import { TransactionService } from '@services/transaction.service';
 import { HttpClient } from './utils';
-import { Config, ConfigKeys } from './config';
+import { Config } from './config';
 import { AuthProvider, AuthProviderSchema } from '@models/auth.models';
 import { TokenService } from '@services/token.service';
 
@@ -13,19 +13,21 @@ export class WalletInfra {
   private httpClient: HttpClient;
   private config: Config;
 
-  constructor(appId: string) {
+  constructor(
+    appId: string,
+    private baseURL: string,
+  ) {
     this.appId = appId;
     this.config = new Config();
-    this.httpClient = new HttpClient();
+    this.httpClient = new HttpClient(baseURL);
     this.Transaction = new TransactionService(this.httpClient);
     this.Token = new TokenService(this.httpClient);
     this.Wallet = new WalletService(this.httpClient);
   }
 
   public generateAuthUrl(redirectUrl: string, provider: AuthProvider): string {
-    const baseURL = this.config.get(ConfigKeys.BASE_URL);
     const parsedProvider = AuthProviderSchema.parse(provider);
-    return `${baseURL}/users/login?oAuthProvider=${parsedProvider}&loginType=WALLET_USER&redirectUrl=${redirectUrl}&appId=${this.appId}`;
+    return `${this.baseURL}/users/login?oAuthProvider=${parsedProvider}&loginType=WALLET_USER&redirectUrl=${redirectUrl}&appId=${this.appId}`;
   }
 
   public authenticateUser(jwt: string) {

--- a/tests/api/token.api.test.ts
+++ b/tests/api/token.api.test.ts
@@ -15,8 +15,8 @@ describe('Token API', () => {
   let httpClientMock: jest.Mocked<HttpClient>;
 
   beforeEach(() => {
-    httpClientMock = new HttpClient() as jest.Mocked<HttpClient>;
-    token = new TokenApi(new HttpClient());
+    httpClientMock = new HttpClient('') as jest.Mocked<HttpClient>;
+    token = new TokenApi(new HttpClient(''));
     // eslint-disable-next-line
     (token as any).httpClient = httpClientMock;
   });

--- a/tests/api/transaction.api.test.ts
+++ b/tests/api/transaction.api.test.ts
@@ -19,8 +19,8 @@ describe('TransactionApi', () => {
   let httpClientMock: jest.Mocked<HttpClient>;
 
   beforeEach(() => {
-    httpClientMock = new HttpClient() as jest.Mocked<HttpClient>;
-    transaction = new TransactionApi(new HttpClient());
+    httpClientMock = new HttpClient('') as jest.Mocked<HttpClient>;
+    transaction = new TransactionApi(new HttpClient(''));
     // eslint-disable-next-line
     (transaction as any).httpClient = httpClientMock;
   });

--- a/tests/api/wallet.api.test.ts
+++ b/tests/api/wallet.api.test.ts
@@ -45,8 +45,8 @@ describe('Wallet', () => {
   };
 
   beforeEach(() => {
-    httpClientMock = new HttpClient() as jest.Mocked<HttpClient>;
-    wallet = new WalletApi(new HttpClient());
+    httpClientMock = new HttpClient('') as jest.Mocked<HttpClient>;
+    wallet = new WalletApi(new HttpClient(''));
     // eslint-disable-next-line
     (wallet as any).httpClient = httpClientMock;
   });

--- a/tests/config/config.test.ts
+++ b/tests/config/config.test.ts
@@ -1,33 +1,21 @@
+import Config from '@config/config';
 import dotenv from 'dotenv';
-import { Config, ConfigKeys } from '@config/index';
+import { ConfigSchema } from '@config/config.interface';
 
 jest.mock('dotenv');
 dotenv.config = jest.fn();
 
 describe('Configuration Tests', () => {
-  let config: Config;
-
   beforeEach(() => {
     jest.resetModules();
   });
-
-  it('should load the base URL from environment variables', async () => {
-    process.env[ConfigKeys.BASE_URL] = 'https://api.test.com';
-    config = new Config();
-    expect(config.get(ConfigKeys.BASE_URL)).toBe('https://api.test.com');
+  it('Should parse the schema', () => {
+    const spy = jest.spyOn(ConfigSchema, 'parse');
+    new Config();
+    expect(spy).toHaveBeenCalled();
   });
-
-  it('should throw an error if BASE_URL is not set', async () => {
-    delete process.env[ConfigKeys.BASE_URL];
-    expect(() => {
-      config = new Config();
-    }).toThrow(/Environment variable BASE_URL is not set/);
-  });
-
-  it('should throw an error if BASE_URL is not a valid URL', () => {
-    process.env[ConfigKeys.BASE_URL] = 'invalid-url';
-    expect(() => {
-      config = new Config();
-    }).toThrow(/Invalid url/);
+  it('Should return an env variable', () => {
+    const value = new Config().get('key');
+    expect(typeof value).toBe('undefined'); // It should be a String but there is no value currently.
   });
 });

--- a/tests/services/token.service.test.ts
+++ b/tests/services/token.service.test.ts
@@ -17,11 +17,11 @@ describe('TokenService', () => {
   let tokenService: TokenService;
 
   beforeEach(() => {
-    tokenApi = new TokenApi(new HttpClient()) as jest.Mocked<TokenApi>;
+    tokenApi = new TokenApi(new HttpClient('')) as jest.Mocked<TokenApi>;
 
     (TokenApi as jest.Mock<TokenApi>).mockImplementation(() => tokenApi);
 
-    tokenService = new TokenService(new HttpClient());
+    tokenService = new TokenService(new HttpClient(''));
   });
 
   afterEach(() => {

--- a/tests/services/transaction.service.test.ts
+++ b/tests/services/transaction.service.test.ts
@@ -22,14 +22,14 @@ describe('TransactionService', () => {
 
   beforeEach(() => {
     transactionApi = new TransactionApi(
-      new HttpClient(),
+      new HttpClient(''),
     ) as jest.Mocked<TransactionApi>;
 
     (TransactionApi as jest.Mock<TransactionApi>).mockImplementation(
       () => transactionApi,
     );
 
-    transactionService = new TransactionService(new HttpClient());
+    transactionService = new TransactionService(new HttpClient(''));
   });
 
   afterEach(() => {

--- a/tests/services/wallet.service.test.ts
+++ b/tests/services/wallet.service.test.ts
@@ -67,11 +67,11 @@ describe('WalletService', () => {
   };
 
   beforeEach(() => {
-    walletApi = new WalletApi(new HttpClient()) as jest.Mocked<WalletApi>;
+    walletApi = new WalletApi(new HttpClient('')) as jest.Mocked<WalletApi>;
 
     (WalletApi as jest.Mock<WalletApi>).mockImplementation(() => walletApi);
 
-    walletService = new WalletService(new HttpClient());
+    walletService = new WalletService(new HttpClient(''));
   });
 
   afterEach(() => {

--- a/tests/utils/http-client.test.ts
+++ b/tests/utils/http-client.test.ts
@@ -22,7 +22,7 @@ describe('HttpClient', () => {
     (Config as jest.Mock<Config>).mockImplementation(() => config);
     config.get = jest.fn().mockReturnValue('http://mocked_base_url');
 
-    httpClient = new HttpClient();
+    httpClient = new HttpClient('http://mocked_base_url');
   });
 
   afterEach(() => {


### PR DESCRIPTION
A BASE_URL environment variable was expected in the environment, however in addition to not seeing the expected errors when not available, frameworks like nextjs require custom names like NEXT_PUBLIC_BASE_URL for client code. Instead in this change the baseURL is now passed in the constructor.

BREAKING CHANGE: The base URL now needs to be passed in the constructor instead of handled in the .env